### PR TITLE
Update spymemcached dependency to 2.12.0 from 2.8.12.

### DIFF
--- a/jetty-nosql-memcached/pom.xml
+++ b/jetty-nosql-memcached/pom.xml
@@ -36,13 +36,6 @@
       </build>
     </profile>
   </profiles>
-  <repositories>
-    <repository>
-      <id>spy</id>
-      <name>Spy Repository</name>
-      <url>http://files.couchbase.com/maven2/</url>
-    </repository>
-  </repositories>
   <dependencies>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
@@ -68,9 +61,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>spy</groupId>
+      <groupId>net.spy</groupId>
       <artifactId>spymemcached</artifactId>
-      <version>2.8.12</version>
+      <version>2.12.0</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.xmemcached</groupId>


### PR DESCRIPTION
spymemcached's own repository setting makes hard to use with gradle.