### PR TITLE
Reduce javadoc warnings

### DIFF
--- a/jetty-nosql-kvs/src/main/java/org/eclipse/jetty/nosql/kvs/KeyValueStoreSessionIdManager.java
+++ b/jetty-nosql-kvs/src/main/java/org/eclipse/jetty/nosql/kvs/KeyValueStoreSessionIdManager.java
@@ -312,6 +312,7 @@ public abstract class KeyValueStoreSessionIdManager extends AbstractSessionIdMan
 
     /**
      * @deprecated from 0.3.0. this is false by default and is not an option.
+     * @param sticky boolean
      */
     @Deprecated
     public void setSticky(final boolean sticky)
@@ -321,6 +322,7 @@ public abstract class KeyValueStoreSessionIdManager extends AbstractSessionIdMan
 
     /**
      * @deprecated from 0.3.0. this is false by default and is not an option.
+     * @return boolean
      */
     @Deprecated
     public boolean isSticky()

--- a/jetty-nosql-kvs/src/main/java/org/eclipse/jetty/nosql/kvs/KeyValueStoreSessionManager.java
+++ b/jetty-nosql-kvs/src/main/java/org/eclipse/jetty/nosql/kvs/KeyValueStoreSessionManager.java
@@ -443,6 +443,7 @@ public class KeyValueStoreSessionManager extends NoSqlSessionManager
     /**
      * @deprecated from 0.3.1. use #{@link org.eclipse.jetty.nosql.kvs.KeyValueStoreSessionManager#getSessionFactory()}
      *             instead.
+     * @return AbstractSessionFactory
      */
     @Deprecated
     public AbstractSessionFactory getSessionFacade()
@@ -454,6 +455,7 @@ public class KeyValueStoreSessionManager extends NoSqlSessionManager
      * @deprecated from 0.3.1. use #
      *             {@link KeyValueStoreSessionManager#setSessionFactory(org.eclipse.jetty.nosql.kvs.session.AbstractSessionFactory)}
      *             instead.
+     * @param sf AbstractSessionFactory
      */
     @Deprecated
     public void setSessionFacade(final AbstractSessionFactory sf)
@@ -474,6 +476,7 @@ public class KeyValueStoreSessionManager extends NoSqlSessionManager
 
     /**
      * @deprecated from 0.3.0. this is false by default and is not an option.
+     * @param sticky boolean
      */
     @Deprecated
     public void setSticky(final boolean sticky)
@@ -483,6 +486,7 @@ public class KeyValueStoreSessionManager extends NoSqlSessionManager
 
     /**
      * @deprecated from 0.3.0. this is false by default and is not an option.
+     * @return boolean
      */
     @Deprecated
     public boolean isSticky()

--- a/jetty-nosql-kvs/src/main/java/org/eclipse/jetty/nosql/kvs/session/ISerializableSession.java
+++ b/jetty-nosql-kvs/src/main/java/org/eclipse/jetty/nosql/kvs/session/ISerializableSession.java
@@ -47,7 +47,7 @@ public interface ISerializableSession {
 
 	/**
 	 * 
-	 * @param attributes
+	 * @param attributes attributes map
 	 */
 	public void setAttributeMap(Map<String, Object> attributes);
 
@@ -103,7 +103,7 @@ public interface ISerializableSession {
 
 	/**
 	 * 
-	 * @param version
+	 * @param version version
 	 */
 	public void setVersion(long version);
 

--- a/jetty-nosql-kvs/src/main/java/org/eclipse/jetty/nosql/kvs/session/ISerializationTranscoder.java
+++ b/jetty-nosql-kvs/src/main/java/org/eclipse/jetty/nosql/kvs/session/ISerializationTranscoder.java
@@ -21,7 +21,7 @@ public interface ISerializationTranscoder {
 	 * serialize an object to byte array
 	 * @param obj to serialize
 	 * @return serialized data
-	 * @throws Exception
+	 * @throws TranscoderException encode error
 	 */
 	public byte[] encode(Object obj) throws TranscoderException;
 
@@ -30,7 +30,7 @@ public interface ISerializationTranscoder {
 	 * @param raw data
 	 * @param klass of serialized data
 	 * @return deserialized object(s)
-	 * @throws Exception
+	 * @throws TranscoderException decode error
 	 */
 	public <T> T decode(byte[] raw, Class<T> klass) throws TranscoderException;
 }


### PR DESCRIPTION
I can't compile because of `MavenReportException: Error while generating Javadoc:`.
Fixed javadoc because there are few warnings.